### PR TITLE
feat: add --laravel-path option

### DIFF
--- a/bin/laravel-nuxt-dev.js
+++ b/bin/laravel-nuxt-dev.js
@@ -27,6 +27,7 @@ program
         "URL path used to render the SPA",
         "/__laravel_nuxt__",
     )
+    .option("--laravel-path [path]", "Path to laravel directory", process.cwd())
     .parse(process.argv);
 
 const NUXT_PORT = parseInt(program.port);
@@ -67,6 +68,7 @@ const laravel = spawn(
         `--port=${LARAVEL_PORT}`,
     ],
     {
+        cwd: program.laravelPath,
         env: Object.assign({}, process.env, {
             NUXT_URL: renderUrl,
             APP_URL: `http://${program.hostname}:${NUXT_PORT}`,


### PR DESCRIPTION
Add --laravel-path option to fix #12 

## Setting Example
### Directory structure
```
SomeProject
├── laravel
│   └── ...
└── nuxt
    ├── nuxt.config.js
    ├── package.json
    └── pages
```

### nuxt\nuxt.config.js
```js
const laravelNuxt = require("laravel-nuxt");

module.exports = laravelNuxt({
  srcDir: __dirname,
  generate: {
    dir: '../laravel/public/'
  },
});
```

### Starting command (in nuxt/package.json)

```
laravel-nuxt dev --laravel-path ../laravel
```