### PR TITLE
Added NODE_OPTS environment to add extra node arguments when using laravel-nuxt-dev.js

### DIFF
--- a/bin/laravel-nuxt-dev.js
+++ b/bin/laravel-nuxt-dev.js
@@ -40,24 +40,27 @@ const renderUrl = new URL(
 
 utils.validateConfig();
 
-const nuxt = spawn(
+let args = [
     which.sync("nuxt"),
-    [
-        "dev",
-        `-c=${utils.configPath}`,
-        "--spa",
-        `--port=${NUXT_PORT}`,
-        `--hostname=${program.hostname}`,
-    ],
-    {
-        env: {
-            ...process.env,
-            LARAVEL_URL: `http://${program.hostname}:${LARAVEL_PORT}`,
-            RENDER_PATH: renderUrl.pathname,
-        },
-        detached: true,
+    "dev",
+    `-c=${utils.configPath}`,
+    "--spa",
+    `--port=${NUXT_PORT}`,
+    `--hostname=${program.hostname}`,
+];
+
+if (process.env.NODE_OPTS) {
+    args.unshift(process.env.NODE_OPTS);
+}
+
+const nuxt = spawn(which.sync("node"), args, {
+    env: {
+        ...process.env,
+        LARAVEL_URL: `http://${program.hostname}:${LARAVEL_PORT}`,
+        RENDER_PATH: renderUrl.pathname,
     },
-);
+    detached: true,
+});
 
 const laravel = spawn(
     "php",


### PR DESCRIPTION
This change to allow to pass parameters to the node executable when setting the environment variable `NODE_OPTS`.

For example, to workaround a limitation of the Header size we would use:

`NODE_OPTS='--max-http-header-size=80000' laravel-nuxt dev`

Thanks,